### PR TITLE
Upgrade arrow dependency to 0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ repositories {
 
 dependencies {
     compile "io.arrow-kt:arrow-core:$arrow_version"
-    compile "io.arrow-kt:arrow-data:$arrow_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     testCompile "io.kotlintest:kotlintest:$kotlintest_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-arrow_version = 0.7.1
+arrow_version = 0.10.5
 dokka_version = 0.9.16
 gradle_bintray_version = 1.8.0
 kotlintest_version = 2.0.7

--- a/src/main/kotlin/com/xenomachina/parser/Parser.kt
+++ b/src/main/kotlin/com/xenomachina/parser/Parser.kt
@@ -19,11 +19,11 @@
 package com.xenomachina.parser
 
 import arrow.core.Either
+import arrow.core.NonEmptyList
 import arrow.core.None
 import arrow.core.Option
-import arrow.data.NonEmptyList
-import arrow.data.Validated
-import arrow.data.ValidatedNel
+import arrow.core.Validated
+import arrow.core.ValidatedNel
 import com.xenomachina.chain.Chain
 import com.xenomachina.chain.asChain
 import java.util.IdentityHashMap

--- a/src/main/kotlin/com/xenomachina/parser/Rule.kt
+++ b/src/main/kotlin/com/xenomachina/parser/Rule.kt
@@ -19,7 +19,7 @@
 package com.xenomachina.parser
 
 import arrow.core.Option
-import arrow.data.Validated
+import arrow.core.Validated
 import com.xenomachina.chain.Chain
 import com.xenomachina.chain.buildChain
 import com.xenomachina.chain.chainOf

--- a/src/test/kotlin/com/xenomachina/parser/ParserTest.kt
+++ b/src/test/kotlin/com/xenomachina/parser/ParserTest.kt
@@ -21,7 +21,7 @@ package com.xenomachina.parser
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option
-import arrow.data.Validated
+import arrow.core.Validated
 import com.xenomachina.chain.Chain
 import io.kotlintest.matchers.shouldEqual
 import io.kotlintest.matchers.shouldThrow


### PR DESCRIPTION
Some classes have been moved into `arrow.core` in newer versions of arrow, so current kessel is not forward-compatible with those versions - would it be possible to release a version that works with 0.10 like this?