### PR TITLE
Upgrade to Kotlin 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,6 @@ apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
 
-kotlin { experimental { coroutines 'enable' } }
-
 assert name == 'kessel'
 group 'com.xenomachina'
 description = "Parser combinators for Kotlin"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ arrow_version = 0.10.5
 dokka_version = 0.9.16
 gradle_bintray_version = 1.8.0
 kotlintest_version = 2.0.7
-kotlin_version = 1.2.41
+kotlin_version = 1.3.72
 ktlint_version = 0.20.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip

--- a/src/main/kotlin/com/xenomachina/chain/Chain.kt
+++ b/src/main/kotlin/com/xenomachina/chain/Chain.kt
@@ -18,9 +18,6 @@
 
 package com.xenomachina.chain
 
-import kotlin.coroutines.experimental.SequenceBuilder
-import kotlin.coroutines.experimental.buildIterator
-
 /**
  * A `Chain` represents a sequence of values. Like `Sequence`, a `Chain` is lazy, but unlike `Sequence`, earlier
  * points along the chain can be remembered, which is useful for backtracking. A `Chain` is immutable, modulo laziness.
@@ -74,8 +71,8 @@ operator fun <T, R : Chain<T>> Chain.Empty.plus(that: () -> R): R =
 operator fun <T> Chain.NonEmpty<T>.plus(that: () -> Chain<T>): Chain.NonEmpty<T> =
         Chain.NonEmpty(head) { tail + that }
 
-fun <T> buildChain(builderAction: suspend SequenceBuilder<T>.() -> Unit): Chain<T> =
-        buildIterator(builderAction).asChain()
+fun <T> buildChain(builderAction: suspend SequenceScope<T>.() -> Unit): Chain<T> =
+        iterator(builderAction).asChain()
 
 class ChainIterator<out T> internal constructor (chain: Chain<T>) : Iterator<T> {
     // For some reason, Kotlin didn't like it when I just used "private set", so simulate it in this roundabout way...

--- a/src/main/kotlin/com/xenomachina/parser/RegexTokenizer.kt
+++ b/src/main/kotlin/com/xenomachina/parser/RegexTokenizer.kt
@@ -20,7 +20,6 @@ package com.xenomachina.parser
 
 import java.util.regex.MatchResult
 import java.util.regex.Matcher
-import kotlin.coroutines.experimental.buildSequence
 
 /**
  * Constructs a token from a [MatchResult].
@@ -61,7 +60,7 @@ class RegexTokenizer<T>(
      * longest match is used to construct a token. It then advances to the next
      * position in the `CharSequence`.
      */
-    override fun <P> tokenize(positionTracker: PositionTracker<P>, chars: CharSequence): Sequence<Positioned<P, T>> = buildSequence {
+    override fun <P> tokenize(positionTracker: PositionTracker<P>, chars: CharSequence): Sequence<Positioned<P, T>> = sequence {
         val length = chars.length
         val matchersToHandlers = patternsToHandlers.map { (pattern, f) -> pattern.matcher(chars) to f }
 

--- a/src/main/kotlin/com/xenomachina/parser/Rule.kt
+++ b/src/main/kotlin/com/xenomachina/parser/Rule.kt
@@ -25,7 +25,6 @@ import com.xenomachina.chain.buildChain
 import com.xenomachina.chain.chainOf
 import com.xenomachina.chain.plus
 import java.util.IdentityHashMap
-import kotlin.coroutines.experimental.SequenceBuilder
 
 abstract class Rule<in T, out R> {
     internal abstract fun <Q : T> partialParse(
@@ -408,12 +407,12 @@ class Sequence7Rule<T, A, B, C, D, E, F, G, Z>(
             } as Chain.NonEmpty<PartialResult<Q, Z>>
 }
 
-private suspend inline fun <T, Z, Q : T, R> SequenceBuilder<PartialResult<Q, Z>>.forSequenceSubRule(
+private suspend inline fun <T, Z, Q : T, R> SequenceScope<PartialResult<Q, Z>>.forSequenceSubRule(
     rule: Rule<T, R>,
     consumed: Int,
     breadcrumbs: Map<Rule<*, *>, Int>,
     chain: Chain<Q>,
-    crossinline body: suspend SequenceBuilder<PartialResult<Q, Z>>.(PartialResult<Q, R>, R) -> Unit
+    crossinline body: suspend SequenceScope<PartialResult<Q, Z>>.(PartialResult<Q, R>, R) -> Unit
 ) {
     for (partial in rule.call(consumed, breadcrumbs, chain)) {
         when (partial.value) {


### PR DESCRIPTION
Hi, with the release of Kotlin 1.4, Kotlin 1.2 has been deprecated and this means some of the Kotlin API calls used in this project cause runtime errors with Kotlin 1.4.
This PR upgrades the build and the version of Kotlin to support running on 1.3 and 1.4.
The only noteworthy change is about coroutines, which are now part of the standard API